### PR TITLE
Fixed everything I could

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,12 @@ manpages: dh-make-pecl.1.gz dh-make-pear.1.gz
 dh-make-pecl.1.gz: man/dh-make-pecl.xml
 	$(XP) $(DB2MAN) $<
 	rm -f dh-make-pecl.1.gz
-	gzip -9 dh-make-pecl.1
+	gzip -n -9 dh-make-pecl.1
 	
 dh-make-pear.1.gz: man/dh-make-pear.xml
 	$(XP) $(DB2MAN) $<
 	rm -f dh-make-pear.1.gz
-	gzip -9 dh-make-pear.1
+	gzip -n -9 dh-make-pear.1
 	
 install: install-bin install-share install-man
 

--- a/debian/README.Debian
+++ b/debian/README.Debian
@@ -2,7 +2,7 @@ dh-make-php for Debian
 ----------------------
 
 dh-make-php contains two programs dh-make-pecl and  dh-make-pear
-to faciliate the creation of source packages from PECL or PEAR
+to facilitate the creation of source packages from PECL or PEAR
 extension for PHP>
 
  -- Uwe Steinmann <steinm@debian.org>, Fri, 27 Feb 2004 21:41:12 +0200

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 3.8.1
 
 Package: dh-make-php
 Architecture: all
-Depends: ${misc:Depends}, php-cli | php5-cli, php-pear, cdbs
+Depends: ${misc:Depends}, make | build-essential | dpkg-dev, php-cli | php5-cli, php-pear, cdbs
 Description: Creates Debian source packages for PHP PEAR and PECL extensions
  Contains dh-make-pear and dh-make-pecl, which create Debian source packages
  from PHP PEAR and PECL packages respectively.

--- a/debian/dh-make-php.lintian
+++ b/debian/dh-make-php.lintian
@@ -1,5 +1,7 @@
-dh-make-php: extra-license-file usr/share/dh-make-php/licenses/php-license
-dh-make-php: script-not-executable ./usr/share/dh-make-php/pecl.template/rules
-dh-make-php: script-not-executable ./usr/share/dh-make-php/pecl.template/rules.CDBS
-dh-make-php: script-not-executable ./usr/share/dh-make-php/dh-make-php.lib
-dh-make-php: missing-dep-for-interpreter make => make | build-essential | dpkg-dev (./usr/share/dh-make-php/pear.template/rules)
+dh-make-php: extra-license-file usr/share/dh-make-php/licenses/artistic
+dh-make-php: extra-license-file usr/share/dh-make-php/licenses/bsd
+dh-make-php: extra-license-file usr/share/dh-make-php/licenses/gpl
+dh-make-php: extra-license-file usr/share/dh-make-php/licenses/lgpl
+dh-make-php: script-not-executable usr/share/dh-make-php/pecl.template/phppostinst
+dh-make-php: script-not-executable usr/share/dh-make-php/pecl.template/rules
+dh-make-php: script-not-executable usr/share/dh-make-php/pecl.template/rules.CDBS

--- a/dh-make-php.lib
+++ b/dh-make-php.lib
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 get_maintainer() {
 	if [ -z "${DEBMAINTAINER}" ] ; then
 		echo -n "Guessing Maintainer: "

--- a/man/dh-make-pecl.xml
+++ b/man/dh-make-pecl.xml
@@ -106,8 +106,6 @@ and docbook-xsl in your Build-Depends control field.
       <arg><option>--only <replaceable>4|5</replaceable></option></arg>
       <arg><option>--phpversion <replaceable>4 5</replaceable></option></arg>
       <arg><option>--dont-use-confd</option></arg>
-      <arg><option>--php55-conf</option></arg>
-      <arg><option>--no-php55-conf</option></arg>
       <arg>PACKAGE</arg>
     </cmdsynopsis>
   </refsynopsisdiv>
@@ -271,29 +269,6 @@ and docbook-xsl in your Build-Depends control field.
             Since Version 0.2.1 of dh-make-php this is the default behaviour
             when creating packages. If you prefer the old way of creating
             php pecl packages use this option.
-            </para>
-        </listitem>
-      </varlistentry>
-      <varlistentry>
-        <term><option>--php55-conf</option>
-        </term>
-        <listitem>
-          <para>PHP 5.5 has introduced a new configuration schema for pecl
-					  extensions. This is used by default, if /etc/php5/mods-available
-						is found on the system wher dh-make-pecl runs. This option is
-						provided to explicity turn on PHP 5.5 configuration even if the
-						default is off.
-            </para>
-        </listitem>
-      </varlistentry>
-      <varlistentry>
-        <term><option>--no-php55-conf</option>
-        </term>
-        <listitem>
-          <para>
-						This option is
-						provided to explicity turn off PHP 5.5 configuration even if the
-						default is on.
             </para>
         </listitem>
       </varlistentry>

--- a/peclbuildall.php
+++ b/peclbuildall.php
@@ -7,4 +7,3 @@ foreach($packages as $package) {
 	$cmd = "dh-make-pecl ".$extraoptions. " --maintainer \"".$maintainer."\" ".$package["pkgname"];
 	echo $cmd."\n";
 }
-?>

--- a/phppkginfo
+++ b/phppkginfo
@@ -10,7 +10,7 @@ function usage() {
 	echo "  version      - Version of package\n";
 	echo "  maintainers  - Comma separated list of maintainers\n";
 	echo "  summary      - Short summary of package\n";
-	echo "  description  ¯ Long description of package\n";
+	echo "  description  - Long description of package\n";
 	echo "  packagerversion - Version of packager\n";
 	echo "  package      - Name of package\n";
 	echo "  release_license - License of released version\n";
@@ -173,5 +173,3 @@ if(get_class($pf) == "PEAR_PackageFile_v1") {
 		default:
 	}
 }
-
-?>


### PR DESCRIPTION
@jvrsantacruz Thank you very much for your work!

Backported lintian says:
```
lintian --display-info --display-experimental --pedantic --show-overrides --no-tag-display-limit ../dh-make-php_0.6.1_all.deb
I: dh-make-php: extended-description-is-probably-too-short
O: dh-make-php: extra-license-file usr/share/dh-make-php/licenses/artistic
O: dh-make-php: extra-license-file usr/share/dh-make-php/licenses/bsd
O: dh-make-php: extra-license-file usr/share/dh-make-php/licenses/gpl
O: dh-make-php: extra-license-file usr/share/dh-make-php/licenses/lgpl
O: dh-make-php: script-not-executable usr/share/dh-make-php/pecl.template/phppostinst
O: dh-make-php: script-not-executable usr/share/dh-make-php/pecl.template/rules
O: dh-make-php: script-not-executable usr/share/dh-make-php/pecl.template/rules.CDBS
E: dh-make-php: php-script-but-no-phpX-cli-dep usr/share/dh-make-php/phppkginfo
```

The last error is because of `php-cli` depends, I run it on jessie.