### PR TITLE
PHP7 excludes xml extension

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 3.8.1
 
 Package: dh-make-php
 Architecture: all
-Depends: ${misc:Depends}, make | build-essential | dpkg-dev, php-cli | php5-cli, php-pear, cdbs
+Depends: ${misc:Depends}, make | build-essential | dpkg-dev, php-cli | php5-cli, php-xml | php5-cli, php-pear, cdbs
 Description: Creates Debian source packages for PHP PEAR and PECL extensions
  Contains dh-make-pear and dh-make-pecl, which create Debian source packages
  from PHP PEAR and PECL packages respectively.


### PR DESCRIPTION
We need `php-xml` but only on PHP7.
This is a dirty hack if don't want to maintain 2 branches.

The solution was stolen from dotdeb's php-pear:
`Depends: php-cli | php5-cli, php-common | php5-common, php-xml | php5-cli`
